### PR TITLE
introduce order_by

### DIFF
--- a/Models/Task.php
+++ b/Models/Task.php
@@ -31,7 +31,8 @@ class Task extends Model
         // prepare
         // dbhのメソッド
         // PDOインスタンスのメソッド
-        $stmt = $this->db_manager->dbh->prepare('SELECT * FROM ' . $this->table);
+        $stmt = $this->db_manager->dbh->prepare('SELECT * FROM ' . $this->table . ' ORDER BY created DESC');
+        
 
         // $dbh === PDOクラスのインスタンス
         // $dbh->prepare('SELECT * FROM ' . $this->table);


### PR DESCRIPTION
# What
Taskの一覧表示を投稿の新しい順番に並び替えた。

# Why
古い投稿が画面の最初にくるよりかは、最初に投稿が最新の物の方が使いやすさが増すため。